### PR TITLE
Remove Quickstart from Documentation section

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -53,7 +53,6 @@
       "group": "Get Started",
       "pages": [
         "what-is-amplication",
-        "quickstart",
         "concepts",
         "faqs"
       ]

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,5 +1,0 @@
----
-title: 'Quickstart'
-description: 'Get started with Amplication quickly. This guide walks platform leads and enterprise developers through the initial setup and basic functionalities.'
-icon: 'rocket'
----


### PR DESCRIPTION
Removing the Quickstart page from the 'Docs' section because it doesn't make sense here.