### PR TITLE
Update: Remove 'How Do Plugins Fit Into Amplication?' Page

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -207,12 +207,6 @@
          ]
       },
       {
-         "group":"Plugin Architecture",
-         "pages":[
-            "plugin-development/how-plugins-fit-into-amplication"
-         ]
-      },
-      {
          "group":"Lifecycle & Coding Details",
          "pages":[
             "plugin-development/before-and-after-lifecycle-functions"


### PR DESCRIPTION
Removing the 'How Do Plugins Fit Into Amplication' page from the Plug in Development section.